### PR TITLE
fix: body태그 x스크롤 삭제

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,6 +87,7 @@ html {
 body {
   font-family: var(--font-family);
   position: relative;
+  overflow-x: hidden;
 }
 
 a {


### PR DESCRIPTION
Safari 브라우저
education 패키지 Slider에서 x축 스크롤이 이동하는 문제 발생하여 overflow-x: hidden속성 추가