### PR TITLE
fix : 카카오 유저 로그인 시 userEmail 누락으로 Orders 확인 불가 이슈

### DIFF
--- a/src/app/(order)/order/history/OrderHistoryClient.tsx
+++ b/src/app/(order)/order/history/OrderHistoryClient.tsx
@@ -12,16 +12,16 @@ import { TrackingResponseEvent } from "@/type/order";
 import Loader from "@/components/loader/Loader";
 import Heading from "@/components/heading/Heading";
 
-interface OrderHistoryClientProps {
-  userEmail: string;
+interface Props {
+  userId: string;
 }
 
-const OrderHistoryClient = ({ userEmail }: OrderHistoryClientProps) => {
+export default function OrderHistoryClient({ userId }: Props) {
   const {
     data: orders,
     error,
     mutate,
-  } = useSWR(["orders", userEmail], () => getOrders(userEmail));
+  } = useSWR(["orders", userId], () => getOrders(userId));
 
   const dispatch = useDispatch();
   const reduxOrders = useSelector(selectOrders);
@@ -76,6 +76,4 @@ const OrderHistoryClient = ({ userEmail }: OrderHistoryClientProps) => {
       </div>
     </section>
   );
-};
-
-export default OrderHistoryClient;
+}

--- a/src/app/(order)/order/history/page.tsx
+++ b/src/app/(order)/order/history/page.tsx
@@ -12,5 +12,5 @@ export default async function OrderHistory() {
   }
   const user = session?.user as UserWithId;
 
-  return <OrderHistoryClient userEmail={user.email} />;
+  return <OrderHistoryClient userId={user.id} />;
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -34,13 +34,16 @@ export const authOptions: AuthOptions = {
       if (!id) {
         return false;
       }
-      await addUser({
+
+      const userData = {
         id,
-        name: name || "",
-        email: email || "",
+        name: name || "Guest User",
+        email: email || `${id}@placeholder.com`,
         image,
-        username: email?.split("@")[0] || "",
-      });
+        username: email ? email.split("@")[0] : id,
+      };
+
+      await addUser(userData);
       return true;
     },
     async jwt({ token, user }) {

--- a/src/services/sanity/orders.ts
+++ b/src/services/sanity/orders.ts
@@ -1,31 +1,11 @@
 import { client } from "@/services/sanity/sanity";
+import { Order } from "@/type/order";
 
-export async function getOrders(email: string) {
-  if (!email) {
-    throw new Error("userId is required");
-  }
-
-  try {
-    const orders = await client.fetch(
-      `*[ _type == "order" && userEmail == $email]{
-        username,
-        userEmail,
-        orderDate,
-        orderAmount,
-        orderStatus,
-        cartItems,
-        billingAddress,
-        shippingAddress,
-        createdAt,
-        shippingInfo,
-        _id
-      }`,
-      { email },
-    );
-    return orders;
-  } catch (error: any) {
-    console.error(`주문 불러오기 실패: ${error.message}`);
-  }
+export async function getOrders(userId: string) {
+  return client.fetch(
+    `*[_type == "order" && userId == $userId] | order(orderDate desc)`,
+    { userId },
+  );
 }
 
 export async function getOrder(orderId: string) {
@@ -72,4 +52,12 @@ export async function updateOrderStatus(
   } catch (error: any) {
     console.error(`주문 상태 변경 실패: ${error.message}`);
   }
+}
+
+export async function createOrder(orderData: Order) {
+  const order = {
+    _type: "order",
+    ...orderData,
+  };
+  return client.create(order);
 }

--- a/src/type/order.ts
+++ b/src/type/order.ts
@@ -1,7 +1,9 @@
 import { CartItem } from "./cart";
 
 export type Order = {
+  userId: string;
   userEmail: string;
+  displayName: string;
   orderDate: string;
   createdAt: string;
   orderAmount: number;

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -1,8 +1,7 @@
-
 export type User = {
-  name: string;
-  email: string;
-  username: string;
+  id: string;
+  name?: string;
+  email?: string;
+  username?: string;
   image?: string;
-}
-
+};


### PR DESCRIPTION
## [#45] fix : 카카오 유저 로그인 시 userEmail 누락으로 Orders 확인 불가 이슈

### 문제 발생 원인

카카오 로그인 시 userEmail이 누락되는 이슈가 있습니다.
카카오는 사업자 등록을 하지 않으면, 로그인 세션 정보로 **email**을 반환해주지 않습니다.

세션에 저장되는 유저 정보는

```ts
interface user {
  id: string;
  name: string;
  email: string;
  username: string;
  image: string;
}
```
이런 형태인데,
카카오, 네이버의 소셜 로그인에서 이런 형태를 취하고 있었습니다.

```ts
// kakao 로그인 시
interface Kakaouser {
  id: string;
  name: string;
  email: undefined;
  username: undefined;
  image: string;
}
// naver 로그인 시
interface Kakaouser {
  id: string;
  name: undefined;
  email: string;
  username: string;
  image: string;
}
```
카카오의 경우, email과 username이 undefined로 오고,
네이버의 경우, name이 undefined로 오고 있습니다.

name의 경우 로그인 정보 저장용 말고는 사용하는 곳이 없기 때문에, 크게 문제가 안되고 있습니다.
email의 경우 결제 정보와 주문 조회를 할 때 파라미터로 사용되고 있기 때문에 중요한 이슈였습니다.

### 해결
고민을 하던 중, 세 소셜 로그인에서 필수 항목인 id로 주문 조회를 할 수 있도록 변경했습니다.
email의 경우 사업자 등록 이후 카카오에서 email을 받을 수 있도록 설정하면 되지만,
당장 테스트 환경에서 돌아갈 수 있는 로직이 필요하고, email에 의존하는 로직은 확장성이 낮고 위험한 방식이기에
유저 id로 주문 조회 파라미터를 변경했습니다.
```ts
// sanity/order
import { client } from "@/services/sanity/sanity";
import { Order } from "@/type/order";

export async function getOrders(userId: string) {
  return client.fetch(
    `*[_type == "order" && userId == $userId] | order(orderDate desc)`,
    { userId },
  );

// app/(order)/order/history/OrderHistoryClient.tsx
export default function OrderHistoryClient({ userId }: Props) {
  const {
    data: orders,
    error,
    mutate,
  } = useSWR(["orders", userId], () => getOrders(userId));
```

또한, username, name, email이 누락되지 않도록 임시 placeholder를 넣어주었습니다.
```ts
      const userData = {
        id,
        name: name || "Guest User",
        email: email || `${id}@placeholder.com`,
        image,
        username: email ? email.split("@")[0] : id,
      };
```

이후에는 사업자 등록 후에 카카오, 네이버에서 name, email 프로퍼티를 받도록 설정해야합니다.