### PR TITLE
fix : maxDuration 설정 vercel로 변경

### DIFF
--- a/src/app/api/cron/webhook-refresh/route.ts
+++ b/src/app/api/cron/webhook-refresh/route.ts
@@ -4,7 +4,6 @@ import { registerWebhook } from "@/services/deliveryTracker";
 
 // Vercel Cron Job에서 24시간마다 호출
 export const dynamic = "force-dynamic";
-export const maxDuration = 300; // 5분 타임아웃
 
 export async function GET(req: NextRequest) {
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,10 @@
       "path": "/api/cron/webhook-refresh",
       "schedule": "0 0 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "api/cron/webhook-refresh": {
+      "maxDuration": 300
+    }
+  }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/67568122-6b8c-4f25-b4d4-95b91fab90b7)

해당 이슈로 관련 로직 수정하였습니다.

1. 문제 발생 원인
```js
// 이전 코드
export const maxDuration = 300; // 5분 타임아웃
```
이 코드가 빌드 에러를 발생시킨 이유는 다음과 같습니다:
Next.js Route Handlers의 제한사항
Route Segment Configuration 문서에 따르면, Route Handler에서 사용할 수 있는 설정은 제한되어 있습니다:
```js
// 허용되는 설정들
export const dynamic = 'auto' | 'force-dynamic' | 'error' | 'force-static'
export const revalidate = false | 'force-cache' | 0 | number
export const runtime = 'nodejs' | 'edge'
export const preferredRegion = 'auto' | 'global' | 'home' | string | string[]
```
maxDuration은 이 목록에 포함되어 있지 않습니다.
2. Vercel의 함수 타임아웃 설정 방식
Vercel Serverless Functions 문서에 따르면, 함수의 실행 시간 제한은 vercel.json을 통해 설정해야 합니다:
```js
{
  "functions": {
    "api/cron/webhook-refresh": {
      "maxDuration": 300
    }
  }
}
```
왜 이렇게 변경되었나?
관심사의 분리
Vercel Platform Configuration 문서에 따르면, 배포 관련 설정은 vercel.json에서 관리하는 것이 권장됩니다.
코드와 인프라 설정을 분리하여 관리할 수 있습니다.
플랫폼 독립성
Next.js는 Vercel 외의 플랫폼에서도 사용될 수 있어야 합니다.
플랫폼 특정적인 설정은 해당 플랫폼의 설정 파일에서 관리하는 것이 좋습니다.
3. Cron Jobs 설정
Vercel Cron Jobs 문서에 따르면, cron 작업은 다음과 같이 설정해야 합니다:
```js
{
  "crons": [
    {
      "path": "/api/cron/webhook-refresh",
      "schedule": "0 0 * * *"
    }
  ]
}
```
이러한 변경을 통해:
Next.js의 라우트 핸들러는 순수하게 API 로직에만 집중
실행 시간 제한과 같은 인프라 설정은 Vercel 설정으로 분리
Cron 작업 설정도 인프라 레벨에서 관리
이렇게 함으로써 코드의 관심사가 명확히 분리되고, 더 나은 유지보수성을 확보할 수 있습니다.