### PR TITLE
feat: Midas Metall 페이지 및 제품 서비스 개선

### DIFF
--- a/src/app/(brand)/midas-metall/page.tsx
+++ b/src/app/(brand)/midas-metall/page.tsx
@@ -5,6 +5,7 @@ import StoreSection from "./components/StoreSection";
 import VideoSection from "./components/VideoSection";
 import ProductFeatures from "./components/ProductFeatures";
 import BrandLayout from "@/components/brandPage/BrandLayout";
+import { Product } from "@/type/products";
 
 const TITLE_BANNER_TEXT = `MIDAS METALLl은 10년 이상의 경험을 쌓은 팀으로 구성되어, 고객을 위한 우수한 금속 마감 솔루션을 제공하고 있습니다. 금속 선택부터 혼합물 준비, 그리고 표면 마감까지의 모든 단계에서 자체 개발한 MIDAS METALLl 제품을 제공합니다. 숙련된 기술자와 기획자로 이루어져 있어 다양한 금속 솔루션을 고객의 요구에 맞게 개발하고 있습니다. 금, 은, 구리 등 다양한 금속 소재를 사용하여 어떠한 형태의 마감이 가능합니다.`;
 const MIDASMETALL_INFO_TEXT_1 = `마이다스 메탈은 고급 금속 마감 솔루션 분야에서 선도적인 기업으로 손꼽힙니다. IF Material Award 2007에서 수상한 금상과 IF 제품 디자인 어워드 2007에서의 주목을 통해 기술적 우수성과 디자인적 창의성을 입증하였습니다.`;
@@ -13,7 +14,7 @@ const MIDASMETALL_INFO_TEXT_3 = `이어진 2010년에는 튀링겐 창립자상�
 const MIDASMETALL_ARTWORK_TEXT = `마이다스 메탈 페인트로 창조된 다채로운 작품들을 확인하세요. 고유한 텍스처와 색상으로 표현된 예술적인 아트워크를 확인할 수 있습니다.`;
 
 export default async function MidasMetall() {
-  const products = await getProducts();
+  const products: Product[] = await getProducts();
 
   return (
     <BrandLayout

--- a/src/services/sanity/products.ts
+++ b/src/services/sanity/products.ts
@@ -1,9 +1,8 @@
 import { client, urlForDetailImage } from "@/services/sanity/sanity";
-import { Product } from "@/type/products";
 
 export function getProducts() {
   try {
-    const products: Promise<Product[]> = client.fetch(
+    const products = client.fetch(
       '*[_type == "product"] {..., mainImage {"imageUrl": asset->url}}',
     );
     return products;
@@ -12,7 +11,7 @@ export function getProducts() {
   }
 }
 
-export async function getDetailProduct(id: string) {
+export function getDetailProduct(id: string) {
   try {
     const product = client
       .fetch(


### PR DESCRIPTION
- Midas Metall 페이지에서 제품 정보를 가져오는 로직을 개선하여 TypeScript의 Product 타입을 사용하도록 수정했습니다.
- 제품 목록을 가져오는 getProducts 함수에서 Promise 타입을 제거하여 코드 간결성을 높였습니다.
- 페이지 구성 요소의 구조를 유지하면서 코드의 가독성을 향상시켰습니다.