### PR TITLE
56 brand subcategory publish

### DIFF
--- a/src/app/(product)/store/BrandsSlider.tsx
+++ b/src/app/(product)/store/BrandsSlider.tsx
@@ -8,7 +8,7 @@ import MidasMetalLogo from "@/assets/product/midas-metal-logo-inverted.png";
 import MetalEffectLogo from "@/assets/product/metal-effect-logo.png";
 import ColorFastLogo from "@/assets/product/color-fast-logo.png";
 import Image from "next/image";
-import CategoryToSearchLink from "./CategoryToSearchLink";
+import Link from "next/link";
 import URLS from "@/constants/urls";
 import { Mobile } from "@/hooks/useMediaQuery";
 
@@ -16,30 +16,26 @@ const slideData = [
   {
     id: 1,
     title: "모던마스터즈",
-    query: "modernMasters",
+    query: "/modernMasters",
     imageUrl: ModernMastersLogo,
-    to: "/store/modern-masters",
   },
   {
     id: 2,
     title: "마이다스메탈",
-    query: "midasMetal",
+    query: "/midasMetal",
     imageUrl: MidasMetalLogo,
-    to: "/store/midas-metal",
   },
   {
     id: 3,
     title: "메탈이펙트",
-    query: "metalEffect",
+    query: "/modernMasters/metalEffect",
     imageUrl: MetalEffectLogo,
-    to: "/store/metal-effect",
   },
   {
     id: 4,
     title: "컬러패스트",
-    query: "colorFast",
+    query: "/modernMasters/colorFast",
     imageUrl: ColorFastLogo,
-    to: "/store/color-fast",
   },
 ];
 
@@ -55,10 +51,9 @@ const BrandSlider = () => {
         autoplay={false}
       >
         {slideData.map(slide => (
-          <CategoryToSearchLink
+          <Link
             key={slide.id}
-            to={URLS.PRODUCT_STORE_SEARCH} // 추후 수정 (Issue #20)
-            searchQuery={slide.query}
+            href={`${URLS.PRODUCT_STORE_BRAND}/${slide.query}`}
           >
             <div className="flex flex-col w-56 h-auto items-center justify-center mx-2">
               <div className="flex w-56 h-32 justify-center items-center border border-stone-300 rounded-lg relative">
@@ -75,7 +70,7 @@ const BrandSlider = () => {
                 {slide.title}
               </div>
             </div>
-          </CategoryToSearchLink>
+          </Link>
         ))}
       </Slider>
     );
@@ -83,10 +78,9 @@ const BrandSlider = () => {
     return (
       <article className="grid grid-cols-2 gap-5">
         {slideData.map(slide => (
-          <CategoryToSearchLink
+          <Link
             key={slide.id}
-            to={URLS.PRODUCT_STORE_SEARCH} // 추후 수정 (Issue #20)
-            searchQuery={slide.query}
+            href={`${URLS.PRODUCT_STORE_BRAND}/${slide.query}`}
           >
             <div className="flex flex-col w-full h-full min-h-[170px] max-h-[200px] items-center justify-center">
               <div className="flex w-full h-full p-4 justify-center items-center border border-stone-300 rounded-lg relative">
@@ -103,7 +97,7 @@ const BrandSlider = () => {
                 {slide.title}
               </div>
             </div>
-          </CategoryToSearchLink>
+          </Link>
         ))}
       </article>
     );

--- a/src/app/(product)/store/CategoryToSearchLink.tsx
+++ b/src/app/(product)/store/CategoryToSearchLink.tsx
@@ -1,5 +1,6 @@
 "use client";
-
+// legacy
+// (product)/store
 import Link from "next/link";
 import { useDispatch } from "react-redux";
 import { setSearchQuery } from "@/redux/slice/searchSlice";

--- a/src/app/(product)/store/ProductBanner.tsx
+++ b/src/app/(product)/store/ProductBanner.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import Banner1 from "@/assets/product/Product-Banner1.png";
 import Banner2 from "@/assets/product/Product-Banner2.png";
-import CategoryToSearchLink from "./CategoryToSearchLink";
 import URLS from "@/constants/urls";
 import Link from "next/link";
 

--- a/src/app/(product)/store/ProductBanner.tsx
+++ b/src/app/(product)/store/ProductBanner.tsx
@@ -3,20 +3,25 @@ import Banner1 from "@/assets/product/Product-Banner1.png";
 import Banner2 from "@/assets/product/Product-Banner2.png";
 import CategoryToSearchLink from "./CategoryToSearchLink";
 import URLS from "@/constants/urls";
+import Link from "next/link";
 
 const ProductBanner = () => {
   const banners = [
-    { img: Banner1, title: "메탈이펙트", query: "metalEffect" },
-    { img: Banner2, title: "컬러패스트", query: "colorFast" },
+    {
+      img: Banner1,
+      title: "메탈이펙트",
+      query: "/modernMasters/metalEffect",
+    },
+    {
+      img: Banner2,
+      title: "컬러패스트",
+      query: "/modernMasters/colorFast",
+    },
   ];
   return (
     <div className="flex sm:w-full sm:flex-col gap-5 mt-24">
       {banners.map((banner, index) => (
-        <CategoryToSearchLink
-          key={index}
-          to={URLS.PRODUCT_STORE_SEARCH} // 추후 수정 (Issue #20)
-          searchQuery={banner.query}
-        >
+        <Link key={index} href={`${URLS.PRODUCT_STORE_BRAND}/${banner.query}`}>
           <div
             className={
               "sm:w-[80%] w-[644px] sm:h-[121px] h-[245px] relative rounded-[10px]" +
@@ -51,7 +56,7 @@ const ProductBanner = () => {
               />
             </div>
           </div>
-        </CategoryToSearchLink>
+        </Link>
       ))}
     </div>
   );

--- a/src/app/(product)/store/Search.tsx
+++ b/src/app/(product)/store/Search.tsx
@@ -1,4 +1,6 @@
 "use client";
+// legacy
+// (product/store/Search.tsx)
 import { setSearchQuery } from "@/redux/slice/searchSlice";
 import { useDispatch } from "react-redux";
 import { useState } from "react";
@@ -16,7 +18,7 @@ const Search = () => {
   const handleSearch = () => {
     dispatch(setSearchQuery(searchValue));
     if (pathname === "/store") {
-      router.push(URLS.PRODUCT_STORE_SEARCH);
+      // router.push(URLS.PRODUCT_STORE_SEARCH);
     }
   };
 

--- a/src/app/(product)/store/brand/SearchClient.tsx
+++ b/src/app/(product)/store/brand/SearchClient.tsx
@@ -1,4 +1,6 @@
 "use client";
+// legacy
+// (product)/store/search
 import { useSelector } from "react-redux";
 import { RootState } from "@/redux/store";
 import { useState, useEffect } from "react";

--- a/src/app/(product)/store/brand/[[...slug]]/page.tsx
+++ b/src/app/(product)/store/brand/[[...slug]]/page.tsx
@@ -1,0 +1,117 @@
+import { getProducts } from "@/services/sanity/products";
+import { Product } from "@/type/products";
+import ProductCards from "../../ProductCards";
+import { categorys, subCategorys } from "@/constants/categorys";
+
+interface PageProps {
+  params: Promise<{
+    slug?: string[];
+  }>;
+}
+
+export default async function BrandPage({ params }: PageProps) {
+  const [products, resolvedParams] = await Promise.all([getProducts(), params]);
+  const depth = resolvedParams.slug ? resolvedParams.slug.length : 0;
+  if (!products) {
+    return <div>제품이 없습니다.</div>;
+  }
+  const getFilteredProducts = () => {
+    const groupBy = <T, K extends keyof any>(arr: T[], key: (item: T) => K) =>
+      arr.reduce((groups, item) => {
+        const k = key(item);
+        (groups[k] = groups[k] || []).push(item);
+        return groups;
+      }, {} as Record<K, T[]>);
+
+    switch (depth) {
+      case 0:
+        // 모든 제품을 mainCategory별로 그룹화
+        return groupBy(products, (product: Product) => product.mainCategory);
+      case 1:
+        // mainCategory에 해당하는 제품을 subCategory별로 그룹화
+        const mainCategoryProducts = products.filter(
+          product => product.mainCategory === resolvedParams.slug![0],
+        );
+        return groupBy(
+          mainCategoryProducts,
+          (product: Product) => product.subCategory,
+        );
+      case 2:
+        // subCategory에 해당하는 제품만 필터링
+        return products.filter(
+          product =>
+            product.mainCategory === resolvedParams.slug![0] &&
+            product.subCategory === resolvedParams.slug![1],
+        );
+      default:
+        return [];
+    }
+  };
+
+  const filteredProducts = getFilteredProducts();
+
+  const getTitle = () => {
+    switch (depth) {
+      case 0:
+        return "브랜드별 제품";
+      case 1: {
+        const category = categorys.find(
+          cat => cat.value === resolvedParams.slug![0],
+        );
+        return category ? `${category.title}` : "";
+      }
+      case 2: {
+        const mainCategory = categorys.find(
+          cat => cat.value === resolvedParams.slug![0],
+        );
+        const subCategory = subCategorys
+          .find(cat => cat.mainCategory.value === mainCategory?.value)
+          ?.subCategory.find(sub => sub.value === resolvedParams.slug![1]);
+        return subCategory ? `${subCategory.title}` : "";
+      }
+      default:
+        return "";
+    }
+  };
+
+  const getSecondCategory = (category: string) => {
+    switch (depth) {
+      case 0: {
+        const find = categorys.find(cat => cat.value === category);
+        return find ? find.title : category;
+      }
+      case 1: {
+        const mainCategory = categorys.find(
+          cat => cat.value === resolvedParams.slug![0],
+        );
+        const subCategoryGroup = subCategorys.find(
+          cat => cat.mainCategory.value === mainCategory?.value,
+        );
+        const find = subCategoryGroup?.subCategory.find(
+          sub => sub.value === category,
+        );
+        return find ? find.title : category;
+      }
+      default:
+        return category;
+    }
+  };
+
+  return (
+    <main className="w-full mt-8 sm:mt-0 mx-auto mb-[200px] flex flex-col justify-around items-center overflow-x-hidden">
+      <h1 className="text-3xl font-bold text-center my-10">{getTitle()}</h1>
+      {depth < 2 ? (
+        Object.entries(filteredProducts).map(([category, products]) => (
+          <section key={category} className="mb-20">
+            <h2 className="text-2xl font-bold mb-8">
+              {getSecondCategory(category)}
+            </h2>
+            <ProductCards products={products as Product[]} />
+          </section>
+        ))
+      ) : (
+        <ProductCards products={filteredProducts as Product[]} />
+      )}
+    </main>
+  );
+}

--- a/src/app/(product)/store/details/[id]/ProductSummary.tsx
+++ b/src/app/(product)/store/details/[id]/ProductSummary.tsx
@@ -202,13 +202,18 @@ export default function ProductSummary({ product }: { product: Product }) {
               }`}
             >
               <div className="flex items-center gap-4">
-                <span className="text-2xl font-bold text-secondaryRed">
-                  {totalDiscountPercentage}%
-                </span>
-                <span className="text-lg font-bold text-darkGray line-through">
-                  {totalOriginalPrice.toLocaleString()}원
-                </span>
+                {totalDiscountPercentage > 0 && (
+                  <>
+                    <span className="text-2xl font-bold text-secondaryRed">
+                      {totalDiscountPercentage}%
+                    </span>
+                    <span className="text-lg font-bold text-darkGray line-through">
+                      {totalOriginalPrice.toLocaleString()}원
+                    </span>
+                  </>
+                )}
               </div>
+
               <span className="text-2xl font-bold">
                 {totalDiscountedPrice.toLocaleString()}원
               </span>

--- a/src/app/(product)/store/details/[id]/ProductSummary.tsx
+++ b/src/app/(product)/store/details/[id]/ProductSummary.tsx
@@ -33,7 +33,6 @@ export default function ProductSummary({ product }: { product: Product }) {
       ([entry]) => {
         // 요소가 뷰포트 상단을 벗어났는지 확인
         const boundingRect = entry.boundingClientRect;
-        console.log(boundingRect.top);
 
         // 요소가 뷰포트 상단을 벗어났을 때만 fixed 적용
         if (boundingRect.top < 0) {

--- a/src/app/(product)/store/details/[id]/TempItem.tsx
+++ b/src/app/(product)/store/details/[id]/TempItem.tsx
@@ -58,11 +58,6 @@ const TempItem = ({ item, onQuantityChange, onDelete, productName }: Props) => {
           </button>
         </div>
         <div className="flex flex-col items-end min-w-[100px]">
-          {discount > 0 && (
-            <span className="text-xs text-gray-500 line-through">
-              {(price * quantity).toLocaleString()}원
-            </span>
-          )}
           <span className="font-bold text-[22px]">
             {(discountedPrice * quantity).toLocaleString()}원
           </span>

--- a/src/app/(product)/store/page.tsx
+++ b/src/app/(product)/store/page.tsx
@@ -1,7 +1,7 @@
 import { categorys } from "@/constants/categorys";
 import BrandSlider from "./BrandsSlider";
 import ProductBanner from "./ProductBanner";
-import CategoryToSearchLink from "./CategoryToSearchLink";
+import Link from "next/link";
 import URLS from "@/constants/urls";
 import { getProducts } from "@/services/sanity/products";
 import { Product } from "@/type/products";
@@ -10,6 +10,9 @@ import ProductCards from "./ProductCards";
 export default async function Products() {
   const categoryValues = categorys.map(category => category.value);
   const products = await getProducts();
+  if (!products) {
+    return <div>제품이 없습니다.</div>;
+  }
   return (
     <main className="w-full mt-8 sm:mt-0 mx-auto mb-[200px] flex flex-col justify-around items-center overflow-x-hidden">
       <header className="w-full h-52 sm:mt-16 sm:mb-12 mb-[70px] flex justify-center items-center gap-44 relative">
@@ -36,13 +39,12 @@ export default async function Products() {
                 <div className="text-[40px] font-bold sm:pb-5">
                   {categorys[index].title}
                 </div>
-                <CategoryToSearchLink
-                  to={URLS.PRODUCT_STORE_SEARCH} // 추후 수정 (Issue #20)
-                  searchQuery={categorys[index].value}
+                <Link
+                  href={`${URLS.PRODUCT_STORE_BRAND}/${category}`}
                   className="mb-4 text-center text-black text-lg font-bold"
                 >
                   {"상품 더보기 >"}
-                </CategoryToSearchLink>
+                </Link>
               </div>
               <ProductCards
                 key={category}

--- a/src/app/(product)/store/search/page.tsx
+++ b/src/app/(product)/store/search/page.tsx
@@ -1,7 +1,0 @@
-import SearchClient from "./SearchClient";
-
-const page = () => {
-  return <SearchClient />;
-};
-
-export default page;

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -68,10 +68,10 @@ export default function Card({
       </div>
       <div className="hover:underline sm:mt-1 mt-[10px] flex gap-2 items-end">
         <span className="text-rose-500 sm:text-xs text-2xl font-bold leading-[30px]">
-          {discount + "%"}
+          {discount !== 0 ? discount + "%" : ""}
         </span>
         <span className="text-zinc-400 sm:text-[10px] text-lg font-normal line-through leading-[30px] sm:leading-normal">
-          {price.toLocaleString()}원
+          {discount !== 0 ? price.toLocaleString() + "원" : ""}
         </span>
         <span className="text-black sm:text-sm text-2xl font-bold">
           {discountedPrice.toLocaleString()}원

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -25,7 +25,6 @@ export default function Card({
   linkTo,
   titleSize = "xl",
 }: EachProductProps) {
-  console.log(product);
   const { productName: title, options, mainImage } = product;
   const price = options[0].sizes[0].price;
   const discount = options[0].sizes[0].discount;

--- a/src/constants/categorys.ts
+++ b/src/constants/categorys.ts
@@ -9,14 +9,35 @@ export const categorys = [
   },
 ];
 
-export const detailCategorys = [
+export const subCategorys = [
   {
-    title: "실내용 페인트",
-    value: "indoorPaints",
-  },
-  {
-    title: "실외용 페인트",
-    value: "outdoorPaints",
+    mainCategory: { title: "모던 마스터즈", value: "modernMasters" },
+    subCategory: [
+      {
+        title: "메탈이펙트",
+        value: "metalEffect",
+      },
+      {
+        title: "데코레이티브 페인트",
+        value: "decorativePaint",
+      },
+      {
+        title: "메탈릭 페인트",
+        value: "metallicPaint",
+      },
+      {
+        title: "메탈릭 플라스터",
+        value: "metallicPlaster",
+      },
+      {
+        title: "시머스톤",
+        value: "shimmerstone",
+      },
+      {
+        title: "베네치안 플라스터",
+        value: "venetianPlaster",
+      },
+    ],
   },
   // 추가적인 상세 카테고리 리스트
 ];

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -20,7 +20,7 @@ const URLS = {
   ORDER_DETAILS: "/order/details",
   ORDER_HISTORY: "/order/history",
   PRODUCT_STORE: "/store",
-  PRODUCT_STORE_SEARCH: "/store/search",
+  PRODUCT_STORE_BRAND: "/store/brand",
   PRODUCT_DETAILS: "/store/details",
 };
 

--- a/src/services/sanity/products.ts
+++ b/src/services/sanity/products.ts
@@ -1,8 +1,9 @@
 import { client, urlForDetailImage } from "@/services/sanity";
+import { Product } from "@/type/products";
 
-export function getProducts() {
+export async function getProducts(): Promise<Product[] | undefined> {
   try {
-    const products = client.fetch(
+    const products = await client.fetch(
       '*[_type == "product"] {..., mainImage {"imageUrl": asset->url}}',
       {},
       {
@@ -12,9 +13,10 @@ export function getProducts() {
         },
       },
     );
-    return products;
+    return products as unknown as Product[];
   } catch (error: any) {
     console.error(`전체 제품 불러오기 실패: ${error.message}`);
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## feat: 제품 조회 성능 개선을 위한 캐싱 및 재검증 기능 추가
- getProducts와 getDetailProduct 함수에 캐싱 및 재검증 옵션 추가하여 성능 개선
- Sanity 클라이언트의 데이터 조회 최적화를 위해 force-cache 설정 및 3600초 재검증 시간 설정

## refactor: Search 로직 제거 및 Brand Category별 제품 출력
- CategoryToSearchLink 컴포넌트를 next/link로 대체하여 라우팅 개선
- 슬라이드 데이터 쿼리에 선행 슬래시 추가로 일관성 확보
- ProductBanner에서 제품 네비게이션에 next/link 활용
- 더 이상 사용되지 않는 검색 페이지 제거 및 제품 필터링과 표시를 개선하기 위해 새로운 SearchClient와 BrandPage 컴포넌트 추가
- 제품 불러오기 로직의 오류 처리 개선


## refactor: 제품 UI 및 검색 로직 개선
- ProductSummary에서 할인율 0% 시 원본 가격 숨김
- TempItem에서 할인 정보 표시 로직 간소화
- Card 컴포넌트에서 할인율 및 원본 가격 조건부 렌더링
- Search 컴포넌트에서 불필요한 라우팅 로직 제거



