### PR TITLE
feat: 카카오 로그인 지원 및 이메일 처리 로직 개선

### DIFF
--- a/src/app/(education)/education/EducationSlider.tsx
+++ b/src/app/(education)/education/EducationSlider.tsx
@@ -126,7 +126,7 @@ const EducationSlider = ({ courses }: EducationSliderProps) => {
                             styleType="secondary"
                             style="flex-1"
                             onClick={() =>
-                              router.push(`/education/${course._id}`)
+                              router.push(`/education/${classItem._id}`)
                             }
                           >
                             신청하기


### PR DESCRIPTION
- 카카오 로그인 시 이메일이 없어도 로그인 허용
- 카카오 프로필 타입 정의 및 추가 정보 처리 로직 구현
- 세션에 대체 이메일 및 로그인 제공자 정보 포함